### PR TITLE
ci: add OIDC trusted-publishing release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: Release
+
+# Publishes to npm using OIDC trusted publishing (no NPM_TOKEN required).
+# npm automatically generates a signed provenance attestation on publish.
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  id-token: write # required for npm OIDC trusted publishing
+
+concurrency:
+  group: release-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+          package-manager-cache: false # never cache dependencies in release builds
+
+      - name: Enable corepack
+        run: corepack enable
+
+      # Trusted publishing requires npm >= 11.5.1; Node 24 bundles an older npm.
+      - name: Upgrade npm to a trusted-publishing-capable version
+        run: npm install --global npm@latest
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify package.json version matches the release tag
+        run: |
+          PKG_VERSION="v$(node -p "require('./package.json').version")"
+          TAG="${{ github.event.release.tag_name }}"
+          if [ "$PKG_VERSION" != "$TAG" ]; then
+            echo "::error::package.json version ($PKG_VERSION) does not match release tag ($TAG)"
+            exit 1
+          fi
+
+      - name: Build
+        run: pnpm build
+
+      # Do NOT set NODE_AUTH_TOKEN — its presence forces the legacy token path
+      # and disables OIDC trusted publishing. npm publish emits provenance.
+      - name: Publish to npm
+        run: npm publish

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,42 @@
+# Releasing
+
+`@rvoh/dream-plugin-json-snapshot` is published to npm automatically by GitHub Actions using
+[OIDC trusted publishing](https://docs.npmjs.com/trusted-publishers/). No npm
+token is stored anywhere, and every release is published with a signed
+[provenance attestation](https://docs.npmjs.com/generating-provenance-statements/).
+
+## One-time setup (per package, performed by an npm owner)
+
+Automated releases do not work until a maintainer registers this repository as a
+trusted publisher on npm:
+
+1. Sign in to npmjs.com as an owner of `@rvoh/dream-plugin-json-snapshot`.
+2. Open the package page → **Settings** → **Trusted Publishers**.
+3. Add a **GitHub Actions** publisher:
+   - Organization or user: `rvohealth`
+   - Repository: `dream-plugin-json-snapshot`
+   - Workflow filename: `release.yml`
+   - Environment name: _(leave blank)_
+4. Recommended hardening: under **Settings → Publishing access**, select
+   **Require two-factor authentication and disallow tokens**. With trusted
+   publishing in place, no automation token is needed.
+
+## Cutting a release
+
+1. Open a PR that bumps `version` in `package.json` and adds a `CHANGELOG.md`
+   entry, then merge it to `main`.
+2. On GitHub, go to **Releases → Draft a new release**.
+3. Create a new tag named `vX.Y.Z` that exactly matches the `package.json`
+   version (the workflow fails the publish if they differ). Target `main`.
+4. Write the release notes and click **Publish release**.
+5. The **Release** workflow builds the package and publishes it to npm with
+   provenance. Confirm the new version appears on npm with a provenance badge.
+
+## Notes
+
+- The workflow runs on `release: published`, so a _draft_ release does not
+  publish anything until you click **Publish release**.
+- Never add `NODE_AUTH_TOKEN` to the release workflow; its presence forces the
+  legacy token path and disables OIDC trusted publishing.
+- Publishing still runs the package's `prepack`/`build`, so a broken build
+  blocks the release.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "2.1.1",
   "description": "A plugin for extracting model attributes and associations into JSON",
   "author": "RVO Health",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rvohealth/dream-plugin-json-snapshot.git"


### PR DESCRIPTION
## What

Adds an automated npm release pipeline using **OIDC trusted publishing**:

- `.github/workflows/release.yml` — runs on a published GitHub Release, builds, verifies the `package.json` version matches the `vX.Y.Z` tag, and runs `npm publish`. Authenticates via GitHub OIDC, so there is **no `NPM_TOKEN`** stored anywhere. npm generates a signed [provenance attestation](https://docs.npmjs.com/generating-provenance-statements/) automatically.
- `package.json` — pins `publishConfig.access` to `public` (no behavior change; already public).
- `RELEASING.md` — documents the one-time npm trusted-publisher setup and the cut-a-release flow.

## Required one-time setup before this works

An npm owner must register this repo as a trusted publisher: package → Settings → Trusted Publishers → GitHub Actions, org `rvohealth`, workflow `release.yml`. See `RELEASING.md`.

## Notes

- The full multi-DB test matrix is intentionally not re-run on release; it already runs on PRs via `pr-checks.yml`, and a release only fires after main is green. The build still runs, so a broken build blocks publish.
- No GitHub Environment approval gate is configured initially (the workflow-filename pin is the trust control); a required-reviewer environment can be layered on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
