### PR TITLE
Bump patch version for GitHub npm publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.0
+
+- switch to Github action publishing to npmjs.com
+
 ## 2.1.1
 
 - Rewrite `Snapshotable` TSDoc: fix two factual errors (required/passthrough `and`-clause associations throw rather than silently skip; N+1 is now avoided via batched preloads up to 4 levels deep), add internal-use-only framing, document auto-inclusion rationale, soft-deleted record inclusion, and data boundary safety

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0
+## 2.1.2
 
 - switch to Github action publishing to npmjs.com
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream-plugin-json-snapshot",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "A plugin for extracting model attributes and associations into JSON",
   "author": "RVO Health",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream-plugin-json-snapshot",
-  "version": "2.2.0",
+  "version": "2.1.2",
   "description": "A plugin for extracting model attributes and associations into JSON",
   "author": "RVO Health",
   "publishConfig": {


### PR DESCRIPTION
Bumps the package minor version for GitHub releases and signed provenance while publishing to npmjs.com through GitHub Actions.