### PR TITLE
fix: add pnpm_config_strict_dep_builds=false to release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
   publish:
     name: Publish to npm
     runs-on: ubuntu-latest
+    env:
+      pnpm_config_strict_dep_builds: "false"
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+- fix release CI: add pnpm_config_strict_dep_builds=false to suppress esbuild ERR_PNPM_IGNORED_BUILDS
+
 ## 2.1.2
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "name": "@rvoh/dream-plugin-json-snapshot",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "A plugin for extracting model attributes and associations into JSON",
   "author": "RVO Health",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Release CI was failing with `ERR_PNPM_IGNORED_BUILDS: esbuild@0.25.0` — pnpm 11 hard-errors when build scripts haven't been explicitly approved
- The `pr-checks.yml` already had the `pnpm_config_strict_dep_builds: "false"` env var fix (from c83d909); this applies the same fix to `release.yml`
- Bumps to 2.1.3

## Test plan

- [ ] Merge and create a `v2.1.3` GitHub release — the "Publish to npm" job should pass the `pnpm install` step without `ERR_PNPM_IGNORED_BUILDS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x