### PR TITLE
fix: replace CI env workaround with pnpm-workspace.yaml; upgrade to pnpm 11.9.0

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     env:
       NODE_ENV: test
-      pnpm_config_strict_dep_builds: "false"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -58,7 +57,6 @@ jobs:
 
     env:
       NODE_ENV: test
-      pnpm_config_strict_dep_builds: "false"
       PORT: 7778
       DB_USER: dream
       DB_NAME: dream_core_test
@@ -104,7 +102,6 @@ jobs:
 
     env:
       NODE_ENV: test
-      pnpm_config_strict_dep_builds: "false"
       PORT: 7778
       DB_USER: dream
       DB_NAME: dream_core_test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3
+
+- upgrade to pnpm@11.9.0; replace pnpm_config_strict_dep_builds CI workaround with pnpm-workspace.yaml (strictDepBuilds: false, esbuild blocked)
+
 ## 2.1.2
 
 - switch to Github action publishing to npmjs.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "type": "module",
   "name": "@rvoh/dream-plugin-json-snapshot",
-  "version": "2.1.2",
+  "version": "2.1.3",
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b",
   "description": "A plugin for extracting model attributes and associations into JSON",
   "author": "RVO Health",
   "publishConfig": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,13 @@
+# SECURITY — allowBuilds is a supply-chain allowlist. pnpm 10+ blocks ALL
+# dependency lifecycle scripts (postinstall, etc.) by default; that default is
+# the primary defense against Shai-Hulud-class npm worms. Only packages listed
+# below (= true) may run install/build scripts. Keep this MINIMAL — every entry
+# re-opens script execution for that package, so add one only with clear cause.
+# esbuild ships prebuilt platform binaries via optionalDependencies and does not
+# need its postinstall to run; it is listed here (= false / blocked) so pnpm 11
+# does not rewrite this file with placeholder prompts on every non-interactive
+# install (pnpm/pnpm#11574).
+strictDepBuilds: false
+
+allowBuilds:
+  esbuild: false


### PR DESCRIPTION
## Summary

- Adds `pnpm-workspace.yaml` with `strictDepBuilds: false` and `esbuild: false` in `allowBuilds` — the correct pnpm 11 way to suppress `ERR_PNPM_IGNORED_BUILDS` without reopening script execution
- Removes `pnpm_config_strict_dep_builds: "false"` from all three jobs in `pr-checks.yml`
- Bumps version to `2.1.3` and adds `packageManager` field (`pnpm@11.9.0`)

Supersedes #45, which used a CI env var workaround instead.

## Test plan

- [ ] CI passes on this PR (all three jobs: linting, tests, check-no-sync-diff)
- [ ] `pnpm install` locally no longer warns about ignored builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhY4PpeeQcHTxS2kZr1n8x