### PR TITLE
Remove legacy decorator build config

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,20 +1,17 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
-    "target": "es2021",
+    "module": "Node16",
+    "target": "ES2022",
+    "moduleResolution": "node16",
     "strict": true,
     "noImplicitAny": true,
     "declaration": true,
-    "experimentalDecorators": true,
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "skipLibCheck": true,
 
     /* do not require all properties to be initialized in constructor */
     "strictPropertyInitialization": false,
-
-    /* with esnext as target, need to specify this so that Object.defineProperty works */
-    "useDefineForClassFields": false,
 
     /* rootDir and outDir together help maintain dist/src folder */
     "rootDir": "./",


### PR DESCRIPTION
## Summary
- remove legacy TypeScript decorator settings from tsconfig.build.json
- align the stale compatibility config with ES2022 and Node16 module resolution

## Verification
- rg legacy decorator scan across published @rvoh packages in this workspace
- pnpm exec tsc -p ./tsconfig.build.json
- CI=true pnpm lint
- pnpm build